### PR TITLE
Fix plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,23 @@ for each state.
 This plugin is meant to be used in conjunction with the _Timetracking_ plugin for birdhouses in order to be notified when birdhouses are ready to be collected from. 
 
 - Config Menu 
-<img src="https://github.com/hong-niu/runelite-birdhouse-overlay/blob/master/imgs/birdhouse_plugin_config.png" width="300" height="300">
+<img src="imgs/birdhouse_plugin_config.png" width="300" height="300">
 
 - Unbuilt birdhouse 
-<img src="https://github.com/hong-niu/runelite-birdhouse-overlay/blob/master/imgs/birdhouse_unbuilt.png" width="300" height="300">
+<img src="imgs/birdhouse_unbuilt.png" width="300" height="300">
 
 - Built birdhouse, but missing seeds 
-<img src="https://github.com/hong-niu/runelite-birdhouse-overlay/blob/master/imgs/birdhouse_empty.png" width="300" height="300">
+<img src="imgs/birdhouse_empty.png" width="300" height="300">
 
 - Build birdhouse full of seeds 
-<img src="https://github.com/hong-niu/runelite-birdhouse-overlay/blob/master/imgs/birdhouse_full.png" width="300" height="300">
+<img src="imgs/birdhouse_full.png" width="300" height="300">
 
 # Feedback
 Please leave feedback [here](https://forms.gle/bDjHDX1zMPcySKUR9) or submit a Github Issue! 
 
 # Change Log
+- v1.1.0 (March 19, 2023) 
+  - Fixed issue with birdhouses no longer properly displaying state
+  - Upgraded runelite version to latest
 - v1.0.0 (December 27, 2021)
   - Initial release 

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.7.1'
+def runeLiteVersion = '1.9.13.1'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -23,7 +23,7 @@ dependencies {
 	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
 }
 
-group = 'com.example'
+group = 'com.birdhouseOverlay'
 version = '1.0-SNAPSHOT'
 sourceCompatibility = '1.8'
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 }
 
 group = 'com.birdhouseOverlay'
-version = '1.0-SNAPSHOT'
+version = '1.1'
 sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'example'
+rootProject.name = 'runelite-birdhouse-overlay'

--- a/src/main/java/com/birdhouseOverlay/BirdhouseColoringOverlay.java
+++ b/src/main/java/com/birdhouseOverlay/BirdhouseColoringOverlay.java
@@ -51,25 +51,25 @@ class BirdhouseColoringOverlay extends Overlay {
 
         if (!Objects.isNull(meadowNorth))
         {
-            int meadowNorthState = client.getVar(BIRD_HOUSE_MEADOW_NORTH);
+            int meadowNorthState = client.getVarbitValue(BIRD_HOUSE_MEADOW_NORTH);
             birdhouseStateRenderer(meadowNorth, meadowNorthState, graphics);
         }
 
         if (!Objects.isNull(meadowSouth))
         {
-            int meadowSouthState = client.getVar(BIRD_HOUSE_MEADOW_SOUTH);
+            int meadowSouthState = client.getVarbitValue(BIRD_HOUSE_MEADOW_SOUTH);
             birdhouseStateRenderer(meadowSouth, meadowSouthState, graphics);
         }
 
         if (!Objects.isNull(valleyNorth))
         {
-            int valleyNorthState = client.getVar(BIRD_HOUSE_VALLEY_NORTH);
+            int valleyNorthState = client.getVarbitValue(BIRD_HOUSE_VALLEY_NORTH);
             birdhouseStateRenderer(valleyNorth, valleyNorthState, graphics);
         }
 
         if (!Objects.isNull(valleySouth))
         {
-            int valleySouthState = client.getVar(BIRD_HOUSE_VALLEY_SOUTH);
+            int valleySouthState = client.getVarbitValue(BIRD_HOUSE_VALLEY_SOUTH);
             birdhouseStateRenderer(valleySouth, valleySouthState, graphics);
         }
 

--- a/src/main/java/com/birdhouseOverlay/BirdhouseColoringOverlay.java
+++ b/src/main/java/com/birdhouseOverlay/BirdhouseColoringOverlay.java
@@ -51,25 +51,25 @@ class BirdhouseColoringOverlay extends Overlay {
 
         if (!Objects.isNull(meadowNorth))
         {
-            int meadowNorthState = client.getVarbitValue(BIRD_HOUSE_MEADOW_NORTH);
+            int meadowNorthState = client.getVarpValue(BIRD_HOUSE_MEADOW_NORTH);
             birdhouseStateRenderer(meadowNorth, meadowNorthState, graphics);
         }
 
         if (!Objects.isNull(meadowSouth))
         {
-            int meadowSouthState = client.getVarbitValue(BIRD_HOUSE_MEADOW_SOUTH);
+            int meadowSouthState = client.getVarpValue(BIRD_HOUSE_MEADOW_SOUTH);
             birdhouseStateRenderer(meadowSouth, meadowSouthState, graphics);
         }
 
         if (!Objects.isNull(valleyNorth))
         {
-            int valleyNorthState = client.getVarbitValue(BIRD_HOUSE_VALLEY_NORTH);
+            int valleyNorthState = client.getVarpValue(BIRD_HOUSE_VALLEY_NORTH);
             birdhouseStateRenderer(valleyNorth, valleyNorthState, graphics);
         }
 
         if (!Objects.isNull(valleySouth))
         {
-            int valleySouthState = client.getVarbitValue(BIRD_HOUSE_VALLEY_SOUTH);
+            int valleySouthState = client.getVarpValue(BIRD_HOUSE_VALLEY_SOUTH);
             birdhouseStateRenderer(valleySouth, valleySouthState, graphics);
         }
 


### PR DESCRIPTION
Resolves #6 (hopefully)

- v1.1.0 (March 19, 2023) 
  - Fixed issue with birdhouses no longer properly displaying state
  - Upgraded runelite version to latest

I was unable to test this myself because I'm signed on as a Jagex Account beta, and testing this plugin is not supported for jagex accounts. Since the current state is broken anyways, it's unlikely to get more broken, but if you can test this would be super helpful.